### PR TITLE
Functionality updates and cleanup

### DIFF
--- a/.github/workflows/yuzu.yml
+++ b/.github/workflows/yuzu.yml
@@ -81,10 +81,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: yuzu-emu/yuzu-mainline
-      - name: Post checkout
-        run: |
-          git submodule update --init externals/vcpkg
-          git submodule update --init --recursive --depth 1
       - name: Configure git
         if: ${{ inputs.build_type == 'yuzu-ea' }}
         run: |
@@ -128,6 +124,10 @@ jobs:
             let body = await myExec(`GIT_BRANCH=$(git branch --show-current) && git log origin/$GIT_BRANCH..$GIT_BRANCH --pretty=format:"- %s"`);
             core.exportVariable("body",body);
             core.exportVariable("time",new Date().toISOString().slice(0,16))
+      - name: Init submodules
+        run: |
+          git submodule update --init externals/vcpkg
+          git submodule update --init --recursive --depth 1
       - name: Checkout patches
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/yuzu.yml
+++ b/.github/workflows/yuzu.yml
@@ -108,11 +108,8 @@ jobs:
               per_page: 100
             }).then(res => res.data.items);
 
-            let commaSeparatedPRs = "${{ inputs.custom_prs }}";
-            if (commaSeparatedPRs == "") {
-              commaSeparatedPRs = "4042"
-            }
-            const prQuery = "type:pr+is:open+repo:yuzu-emu/yuzu+" + commaSeparatedPRs.split(',').map((n) => n.trim()).join('+');
+            let commaSeparatedPRs = "${{ inputs.custom_prs }}" || "4042";
+            const prQuery = "type:pr+repo:yuzu-emu/yuzu+" + commaSeparatedPRs.split(',').map((n) => n.trim()).join('+');
 
             const customPrs = await github.rest.search.issuesAndPullRequests({
               q: prQuery,

--- a/.github/workflows/yuzu.yml
+++ b/.github/workflows/yuzu.yml
@@ -4,12 +4,11 @@ run-name: 'Build yuzu'
 on:
   workflow_dispatch:
     inputs:
-      build_type:
-        description: 'build type'
+      repo_source:
+        description: 'the source repository for the build. the default "yuzu-emu/yuzu" builds EA, "yuzu-emu/yuzu-mainline" builds mainline; any other repo fork can be used'
         required: true
-        default: 'yuzu-ea'
-        type: choice
-        options: ['yuzu-ea', 'yuzu-mainline']
+        default: 'yuzu-emu/yuzu'
+        type: string
       custom_prs:
         description: 'comma separated list of PR IDs'
         required: false
@@ -71,18 +70,18 @@ jobs:
       ZSTD_CLEVEL: 1
     steps:
       - name: Checkout yuzu-ea
-        if: ${{ inputs.build_type == 'yuzu-ea' }}
+        if: ${{ inputs.repo_source != 'yuzu-emu/yuzu-mainline' }}
         uses: actions/checkout@v4
         with:
-          repository: yuzu-emu/yuzu
+          repository: ${{ inputs.repo_source }}
           fetch-depth: 0
       - name: Checkout yuzu-mainline
-        if: ${{ inputs.build_type == 'yuzu-mainline' }}
+        if: ${{ inputs.repo_source == 'yuzu-emu/yuzu-mainline' }}
         uses: actions/checkout@v4
         with:
-          repository: yuzu-emu/yuzu-mainline
+          repository: ${{ inputs.repo_source }}
       - name: Configure git
-        if: ${{ inputs.build_type == 'yuzu-ea' }}
+        if: ${{ inputs.repo_source != 'yuzu-emu/yuzu-mainline' }}
         run: |
           git config --global user.email "yuzu@yuzu-emu.org"
           git config --global user.name "yuzubot"
@@ -92,7 +91,7 @@ jobs:
       - name: Install Vulkan SDK
         run: .\.ci\scripts\windows\install-vulkan-sdk.ps1
       - name: Merge PRs
-        if: ${{ inputs.build_type == 'yuzu-ea' }}
+        if: ${{ inputs.repo_source != 'yuzu-emu/yuzu-mainline' }}
         uses: actions/github-script@v6
         with: 
           script: |
@@ -105,7 +104,7 @@ jobs:
             }).then(res => res.data.items);
 
             let commaSeparatedPRs = "${{ inputs.custom_prs }}" || "4042";
-            const prQuery = "type:pr+repo:yuzu-emu/yuzu+" + commaSeparatedPRs.split(',').map((n) => n.trim()).join('+');
+            const prQuery = "type:pr+is:open+repo:yuzu-emu/yuzu+" + commaSeparatedPRs.split(',').map((n) => n.trim()).join('+');
 
             const customPrs = await github.rest.search.issuesAndPullRequests({
               q: prQuery,

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Download build from ['Action'](https://github.com/alexkiri/yuzu-build/actions) t
 # Additional functionality
 The workflow includes logic that can:
 - build either `yuzu-ea` or `yuzu-mainline`
-- include any custom PR in the build, even it doesn't have the `early-access-merge` label. This is done by specifying a comma separated list of PR IDs in the workflow input. Use this with caution, as it might cause merge conflicts, build errors, or other unwanted consequences. Can be left empty, and it only works for `yuzu-ea` build type
+- include any custom PR in the build, even it doesn't have the `early-access-merge` label. This is done by specifying a comma separated list of PR IDs in the workflow input. Closed PRs will can also be included. Use this with caution, as it might cause merge conflicts, build errors, or other unwanted consequences. Can be left empty, and it only works for `yuzu-ea` build type
 - make the build enable / disable various cmake flags. You can find some description for each flag in the [CMakeLists.txt](https://github.com/yuzu-emu/yuzu/blob/master/CMakeLists.txt) file
 - apply custom optimization flag for any selectable CPU extension. This is experimental, and it probably has little to not effect
 - apply custom fixes in the form of `.patch` files. There are now 2 folders, 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Download build from ['Action'](https://github.com/alexkiri/yuzu-build/actions) t
 # Additional functionality
 The workflow includes logic that can:
 - build either `yuzu-ea` or `yuzu-mainline`
-- include any custom PR in the build, even it doesn't have the `early-access-merge` label. This is done by specifying a comma separated list of PR IDs in the workflow input. Closed PRs will can also be included. Use this with caution, as it might cause merge conflicts, build errors, or other unwanted consequences. Can be left empty, and it only works for `yuzu-ea` build type
+- include any custom PR in the build, even it doesn't have the `early-access-merge` label. This is done by specifying a comma separated list of PR IDs in the workflow input. Use this with caution, as it might cause merge conflicts, build errors, or other unwanted consequences. Can be left empty, and it only works for `yuzu-ea` build type
 - make the build enable / disable various cmake flags. You can find some description for each flag in the [CMakeLists.txt](https://github.com/yuzu-emu/yuzu/blob/master/CMakeLists.txt) file
 - apply custom optimization flag for any selectable CPU extension. This is experimental, and it probably has little to not effect
 - apply custom fixes in the form of `.patch` files. There are now 2 folders, 


### PR DESCRIPTION
- Replace build_type with with repo_source functionality, allowing to specify a source repository for the build. The default "yuzu-emu/yuzu" builds EA, "yuzu-emu/yuzu-mainline" builds mainline; any other repo fork can be used
- Move submodule init step later, as some PRs can add new submodules
- Cleanup for the custom_prs logic